### PR TITLE
In-app links for button leading to Cascade's website

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
+        supportLibVersion = "28.0.0"
     }
     repositories {
         google()

--- a/components/screens/AboutScreen/SocialMedia/SocialMedia.js
+++ b/components/screens/AboutScreen/SocialMedia/SocialMedia.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Styles } from './SocialMediaStyles';
 import { View, Text, Alert, Pressable, Linking } from 'react-native';
 import Icon from 'react-native-vector-icons/Entypo';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
 
 const StayConnected = () => {
 
@@ -57,13 +58,13 @@ const StayConnected = () => {
         </Pressable>
       </View>
       <View style={Styles.stayConnectedBtn}>
-        <Pressable onPress={() => openURL('https://cascade.org/membership')}>
+        <Pressable onPress={(e) => { e.preventDefault(); InAppBrowser.open('https://cascade.org/membership') }}>
           <Text style={Styles.joinDonateShoptxt}>JOIN</Text>
         </Pressable>
-        <Pressable onPress={() => openURL('https://cascade.org/donate')}>
+        <Pressable onPress={(e) => { e.preventDefault(); InAppBrowser.open('https://cascade.org/donate') }}>
           <Text style={Styles.joinDonateShoptxt}>DONATE</Text>
         </Pressable>
-        <Pressable onPress={() => openURL('https://cbcmerchandise.com/cbc')}>
+        <Pressable onPress={(e) => { e.preventDefault(); InAppBrowser.open('https://cbcmerchandise.com/cbc') }}>
           <Text style={Styles.joinDonateShoptxt}>SHOP</Text>
         </Pressable>
       </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-native": "0.66.0",
         "react-native-elements": "^3.4.2",
         "react-native-gesture-handler": "^1.10.3",
+        "react-native-inappbrowser-reborn": "^3.6.3",
         "react-native-reanimated": "^2.2.3",
         "react-native-safe-area-context": "^3.3.2",
         "react-native-screens": "^3.8.0",
@@ -10120,6 +10121,19 @@
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2"
+      }
+    },
+    "node_modules/react-native-inappbrowser-reborn": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.6.3.tgz",
+      "integrity": "sha512-fqF708GVZ/7zja0/GyJQfjDfKREOe1fxYq8RAKZo8/KK6SkFO9hBlYqC3PwLFPw29zzwBzR+6EpL3qo95igkLw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "opencollective-postinstall": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.56"
       }
     },
     "node_modules/react-native-ratings": {
@@ -20340,6 +20354,15 @@
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-native-inappbrowser-reborn": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.6.3.tgz",
+      "integrity": "sha512-fqF708GVZ/7zja0/GyJQfjDfKREOe1fxYq8RAKZo8/KK6SkFO9hBlYqC3PwLFPw29zzwBzR+6EpL3qo95igkLw==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "opencollective-postinstall": "^2.0.2"
       }
     },
     "react-native-ratings": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-native": "0.66.0",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "^1.10.3",
+    "react-native-inappbrowser-reborn": "^3.6.3",
     "react-native-reanimated": "^2.2.3",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.8.0",


### PR DESCRIPTION
## Description
Imports a new package [react-native-inappbrowser-reborn](https://www.npmjs.com/package/react-native-inappbrowser-reborn). This allows us to link to websites while keeping the users the app itself instead of directing them to an external web app. This will help improve user retention.

Shoutout to @zmagar for finding this library.

## To Test
1. `npm install`
2. Run the metro
3. Run the app
4. Test the "**JOIN**", "**DONATE**", and "**SHOP**" buttons on the bottom of the about screen.